### PR TITLE
Rename projects cache (Rel. issue https://github.com/Netcracker/qubership-testing-platform-datasets/issues/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ This library is used to check user permissions, to perform users authorization a
 
 #### 2. Add Authentication properties into application.properties
 Please note:
- - Exact names of caches are set in auth-library source code in Constants class,
- - So, spring.cache.cache-names setting value should be combined from two constants' values:
-   - Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME
- - And, please check/fix projects cache name in such typical usages of this name:
-   - Old-style usages:
-     - @CacheConfig(cacheNames = {"projects", "auth_objects"})
-     - @Cacheable("projects")
-   - New-style recommendations:
-     - @CacheConfig(cacheNames = {Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME})
-     - @Cacheable(Constants.AUTH_PROJECTS_CACHE_NAME)
+- Exact names of caches are set in auth-library source code in Constants class,
+- So, spring.cache.cache-names setting value should be combined from two constants' values:
+  - Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME
+- And, please check/fix projects cache name in such typical usages of this name:
+  - Old-style usages:
+    - @CacheConfig(cacheNames = {"projects", "auth_objects"})
+    - @Cacheable("projects")
+  - New-style recommendations:
+    - @CacheConfig(cacheNames = {Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME})
+    - @Cacheable(Constants.AUTH_PROJECTS_CACHE_NAME)
 
 ```text
 ##==================atp-auth-spring-boot-starter=====================
@@ -236,15 +236,15 @@ atp.logging.feignclient.headers.ignore=${ATP_HTTP_LOGGING_HEADERS_IGNORE:}
 ```
 
 By default, 'atp.logging.resttemplate.headers' value is false.
- - _atp.logging.resttemplate.headers_ 
-   - To log request/response headers for RelayRestTemplate and M2MRestTemplate.
- - _atp.logging.resttemplate.headers.ignore_ 
-   - To ignore specified headers while logging. Tokens should be separated with spaces.
- - _atp.logging.feignclient.headers_ 
-   - To ignore request/response headers for FeignClient.
- - _atp.logging.feignclient.headers.ignore_ 
-   - To ignore specified headers for FeignClient. Tokens should be separated with spaces.
- - Properties _atp.logging.resttemplate.headers.ignore_ and _atp.logging.feignclient.headers.ignore_ support regular expressions.
+- _atp.logging.resttemplate.headers_
+  - To log request/response headers for RelayRestTemplate and M2MRestTemplate.
+- _atp.logging.resttemplate.headers.ignore_
+  - To ignore specified headers while logging. Tokens should be separated with spaces.
+- _atp.logging.feignclient.headers_
+  - To ignore request/response headers for FeignClient.
+- _atp.logging.feignclient.headers.ignore_
+  - To ignore specified headers for FeignClient. Tokens should be separated with spaces.
+- Properties _atp.logging.resttemplate.headers.ignore_ and _atp.logging.feignclient.headers.ignore_ support regular expressions.
 
 #### 2. Add configuration into logback.xml
 ```xml

--- a/README.md
+++ b/README.md
@@ -22,9 +22,21 @@ This library is used to check user permissions, to perform users authorization a
 ```
 
 #### 2. Add Authentication properties into application.properties
+Please note:
+ - Exact names of caches are set in auth-library source code in Constants class,
+ - So, spring.cache.cache-names setting value should be combined from two constants' values:
+   - Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME
+ - And, please check/fix projects cache name in such typical usages of this name:
+   - Old-style usages:
+     - @CacheConfig(cacheNames = {"projects", "auth_objects"})
+     - @Cacheable("projects")
+   - New-style recommendations:
+     - @CacheConfig(cacheNames = {Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME})
+     - @Cacheable(Constants.AUTH_PROJECTS_CACHE_NAME)
+
 ```text
 ##==================atp-auth-spring-boot-starter=====================
-spring.cache.cache-names: projects, auth_objects
+spring.cache.cache-names: auth_projects, auth_objects
 spring.cache.caffeine.spec: maximumSize=100, expireAfterAccess=120s
 
 keycloak.resource=""
@@ -224,11 +236,15 @@ atp.logging.feignclient.headers.ignore=${ATP_HTTP_LOGGING_HEADERS_IGNORE:}
 ```
 
 By default, 'atp.logging.resttemplate.headers' value is false.
-* _atp.logging.resttemplate.headers_ - To log request/response headers for RelayRestTemplate and M2MRestTemplate.
-* _atp.logging.resttemplate.headers.ignore_ - To ignore specified headers while logging. Tokens should be separated with spaces.
-* _atp.logging.feignclient.headers_ - To ignore request/response headers for FeignClient.
-* _atp.logging.feignclient.headers.ignore_ - To ignore specified headers for FeignClient. Tokens should be separated with spaces.
-* Properties _atp.logging.resttemplate.headers.ignore_ and _atp.logging.feignclient.headers.ignore_ support regular expressions.
+ - _atp.logging.resttemplate.headers_ 
+   - To log request/response headers for RelayRestTemplate and M2MRestTemplate.
+ - _atp.logging.resttemplate.headers.ignore_ 
+   - To ignore specified headers while logging. Tokens should be separated with spaces.
+ - _atp.logging.feignclient.headers_ 
+   - To ignore request/response headers for FeignClient.
+ - _atp.logging.feignclient.headers.ignore_ 
+   - To ignore specified headers for FeignClient. Tokens should be separated with spaces.
+ - Properties _atp.logging.resttemplate.headers.ignore_ and _atp.logging.feignclient.headers.ignore_ support regular expressions.
 
 #### 2. Add configuration into logback.xml
 ```xml

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.qubership.atp.auth</groupId>
     <artifactId>atp-auth-spring-boot-starter</artifactId>
-    <version>1.2.62-SNAPSHOT</version>
+    <version>1.2.68-SNAPSHOT</version>
 
     <properties>
         <atp.common.version>0.0.43</atp.common.version>

--- a/src/main/java/org/qubership/atp/auth/springbootstarter/Constants.java
+++ b/src/main/java/org/qubership/atp/auth/springbootstarter/Constants.java
@@ -20,4 +20,6 @@ public interface Constants {
 
     String AUTHORIZATION_HEADER_NAME = "Authorization";
     String BEARER_TOKEN_TYPE = "Bearer";
+    String AUTH_PROJECTS_CACHE_NAME = "auth_projects";
+    String AUTH_OBJECTS_CACHE_NAME = "auth_objects";
 }

--- a/src/main/java/org/qubership/atp/auth/springbootstarter/services/UsersService.java
+++ b/src/main/java/org/qubership/atp/auth/springbootstarter/services/UsersService.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
+import org.qubership.atp.auth.springbootstarter.Constants;
 import org.qubership.atp.auth.springbootstarter.entities.ObjectPermissions;
 import org.qubership.atp.auth.springbootstarter.entities.Operations;
 import org.qubership.atp.auth.springbootstarter.entities.Permissions;
@@ -42,7 +43,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@CacheConfig(cacheNames = {"projects", "auth_objects"})
+@CacheConfig(cacheNames = {Constants.AUTH_PROJECTS_CACHE_NAME, Constants.AUTH_OBJECTS_CACHE_NAME})
 public class UsersService {
 
     private final UsersFeignClient usersFeignClient;
@@ -57,7 +58,7 @@ public class UsersService {
      *
      * @return {@link Project}
      */
-    @Cacheable("projects")
+    @Cacheable(Constants.AUTH_PROJECTS_CACHE_NAME)
     public Project getUsersByProject(UUID projectId) {
         return usersFeignClient.getUsersByProject(projectId);
     }


### PR DESCRIPTION
To fix Datasets vs. MIA issue: https://github.com/Netcracker/qubership-testing-platform-datasets/issues/4
<!-- start messages -->
### Commit messages:
[kagw95](https://github.com/Netcracker/qubership-testing-platform-auth-library/commit/47e8c74cbc9605de4831ac27d756e37f056cb2bc) Projects cache is renamed. Constants are introduced to hold caches names. Documentation is changed correspondingly.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-auth-library/commit/a705c7245f1566c13f42c777f8cffdf12cdcc581) README.md syntax is fixed.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-auth-library/commit/7a0fd72a5129eabe9bb3d9df525fc489870739e2) Version is changed to 1.2.68-SNAPSHOT.
<!-- end messages -->
